### PR TITLE
Triagem formulario

### DIFF
--- a/components/Checkbox/Checkbox.tsx
+++ b/components/Checkbox/Checkbox.tsx
@@ -1,0 +1,30 @@
+'use client';
+import * as C from '@/components/ui/checkbox';
+import { useState } from 'react';
+import { Label } from '../Label/Label';
+import { CheckboxProps } from './CheckboxProps';
+
+export function Checkbox({ options, name, onChange }: CheckboxProps) {
+  const [selectedValue, setSelectedValue] = useState<string | null>(null);
+
+  const handleChange = (value: string) => {
+    setSelectedValue(value);
+    if (onChange) onChange(value);
+  }
+
+  return (
+    <div className='flex'>
+      {options.map((o) => (
+        <div key={o.value} className='flex items-center gap-1'>
+          <C.Root
+            checked={selectedValue === o.value}
+            onCheckedChange={() => handleChange(o.value)}
+            id={`${name}-${o.value}`} />
+          <Label
+            label={o.label}
+            htmlFor={`${name}-${o.value}`} />
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/Checkbox/CheckboxProps.ts
+++ b/components/Checkbox/CheckboxProps.ts
@@ -1,0 +1,5 @@
+export interface CheckboxProps {
+  options: { label: string; value: string }[],
+  name: string,
+  onChange?: (value: string) => void
+}

--- a/components/Dropdown/Dropdown.tsx
+++ b/components/Dropdown/Dropdown.tsx
@@ -1,0 +1,23 @@
+'use client';
+import * as Select from '@/components/ui/select';
+import { DropdownProps } from './DropdownProps';
+
+export function Dropdown({ options, placeholder }: DropdownProps) {
+
+  return (
+    <div className='w-full'>
+      <Select.Root>
+        <Select.Trigger aria-label={placeholder}>
+          <Select.Value placeholder={placeholder} />
+        </Select.Trigger>
+        <Select.Content>
+          {options.map((op) => (
+            <Select.Item key={op.value} value={op.value}>
+              {op.label}
+            </Select.Item>
+          ))}
+        </Select.Content>
+      </Select.Root>
+    </div>
+  );
+}

--- a/components/Dropdown/DropdownProps.ts
+++ b/components/Dropdown/DropdownProps.ts
@@ -1,0 +1,4 @@
+export interface DropdownProps {
+  options: { label: string; value: string }[],
+  placeholder?: string
+}

--- a/components/FormField/FormField.tsx
+++ b/components/FormField/FormField.tsx
@@ -1,0 +1,28 @@
+import { Hint } from "../Hint/Hint";
+import { Input } from "../Input/Input";
+import { Label } from "../Label/Label";
+import { FormFieldProps } from "./FormFieldProps";
+
+export function FormField({ label, type, value, placeholder, onChange, icon, message, showError, ...rest }: FormFieldProps) {
+  return (
+    <>
+      <Label
+        label={label}
+        {...rest} />
+
+      <Input
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        onChange={onChange}
+        {...rest} />
+
+      {showError && (
+        <Hint
+          icon={icon}
+          message={message}
+          {...rest} />
+      )}
+    </>
+  )
+}

--- a/components/FormField/FormFieldProps.ts
+++ b/components/FormField/FormFieldProps.ts
@@ -1,0 +1,12 @@
+import { ChangeEvent, ElementType, InputHTMLAttributes } from "react";
+
+export interface FormFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label: string,
+  type: 'text' | 'password' | 'email' | 'number' | 'date',
+  value: string,
+  placeholder: string,
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void,
+  showError?: boolean,
+  icon?: ElementType,
+  message?: string
+}

--- a/components/Hint/Hint.tsx
+++ b/components/Hint/Hint.tsx
@@ -1,0 +1,11 @@
+import * as H from '@/components/ui/hint';
+import { HintProps } from './HintProps';
+
+export function Hint({ message, icon, ...rest }: HintProps) {
+  return (
+    <H.Root {...rest}>
+      <H.Icon as={icon} />
+      {message}
+    </H.Root>
+  );
+}

--- a/components/Hint/HintProps.ts
+++ b/components/Hint/HintProps.ts
@@ -1,0 +1,7 @@
+import { ElementType } from "react";
+
+export interface HintProps {
+  icon?: ElementType,
+  message?: string,
+  hasError?: boolean
+}

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -1,0 +1,38 @@
+'use client';
+import * as I from '@/components/ui/input';
+import {
+  RiEyeLine,
+  RiEyeOffLine
+} from '@remixicon/react';
+import { useState } from 'react';
+import { InputProps } from './InputProps';
+
+export function Input({ type, value, placeholder, iconStart, onChange, size, ...rest }: InputProps) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className='w-full'>
+      <I.Root>
+        <I.Wrapper>
+          {iconStart && <I.Icon as={iconStart} />}
+          <I.Input
+            {...rest}
+            onChange={onChange}
+            value={value}
+            type={type === "password" ? (showPassword ? "text" : "password") : type}
+            placeholder={placeholder} />
+
+          {type === 'password' && (
+            <button type='button' onClick={() => setShowPassword((s) => !s)}>
+              {showPassword ? (
+                <RiEyeOffLine className='size-5 text-text-soft-400 group-has-[disabled]:text-text-disabled-300' />
+              ) : (
+                <RiEyeLine className='size-5 text-text-soft-400 group-has-[disabled]:text-text-disabled-300' />
+              )}
+            </button>
+          )}
+        </I.Wrapper>
+      </I.Root>
+    </div>
+  );
+}

--- a/components/Input/InputProps.ts
+++ b/components/Input/InputProps.ts
@@ -1,0 +1,10 @@
+import { ChangeEvent, ElementType, InputHTMLAttributes } from "react";
+
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  type: 'text' | 'password' | 'email' | 'number' | 'date';
+  value: string,
+  placeholder: string,
+  iconStart?: ElementType,
+  hasError?: boolean,
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void
+}

--- a/components/Label/Label.tsx
+++ b/components/Label/Label.tsx
@@ -1,0 +1,14 @@
+import * as L from '@/components/ui/label';
+import { LabelProps } from './LabelProps';
+
+export function Label({ label, observacao, campoObrigatorio, ...rest }: LabelProps) {
+  return (
+    <L.Root className='pb-1' {...rest}>
+      {label}
+      {campoObrigatorio && (
+        <L.Asterisk className='text-[#008B62]' />
+      )}
+      <L.Sub className='text-neutral-400 pl-1'>{observacao}</L.Sub>
+    </L.Root>
+  );
+}

--- a/components/Label/LabelProps.ts
+++ b/components/Label/LabelProps.ts
@@ -1,0 +1,6 @@
+export interface LabelProps {
+  label: string,
+  observacao?: string,
+  campoObrigatorio?: boolean,
+  htmlFor?: string
+}

--- a/components/Textearea/Textearea.tsx
+++ b/components/Textearea/Textearea.tsx
@@ -1,0 +1,20 @@
+'use client';
+import * as T from '@/components/ui/textarea';
+import { TexteareaProps } from './TexteareaProps';
+
+export function Textarea({ placeholder, value, onChange, ...rest }: TexteareaProps) {
+  return (
+    <div className='w-full'>
+      <T.Root
+        {...rest}
+        placeholder={placeholder}
+        value={value}
+        onChange={onChange}>
+
+        <T.CharCounter
+          current={value.length}
+          max={500} />
+      </T.Root>
+    </div>
+  );
+}

--- a/components/Textearea/TexteareaProps.ts
+++ b/components/Textearea/TexteareaProps.ts
@@ -1,0 +1,8 @@
+import { ChangeEvent, TextareaHTMLAttributes } from "react";
+
+export interface TexteareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>  {
+  value: string,
+  placeholder: string,
+  hasError?: boolean,
+  onChange:  (e: ChangeEvent<HTMLTextAreaElement>) => void
+}


### PR DESCRIPTION
# Componentes Reutilizáveis:
Adicionado a maioria dos componentes pertencentes a tela de triagem - formulário 

## Descrição:
**O que foi feito?**
- Componente **Textearea**: com contador de caracteres
- Componente  **Label**: possibilidade de mostrar asterisco para campo obrigatório e inserir observação
- Componente **Input**: possível passar o type e, se for password, já aparece o toggle, também pode inserir ícone no início do campo
- Componente **Hint**: responsável por mostrar uma informação pro usuário
- Componente **FormField:** junção do label + input + hint
- Componente **Dropdown:** responsável por apresentar as opções pro usuário 
- Componente **Checkbox:** funciona da maneira em que somente um elemento pode ser checked

**Observações sobre as props:**
hasError: prop que permite mudar a cor do elemento, tipo boolean
options: usado para passar múltiplas informações -> **{ [ { label: "testando", value: "teste" }, { label: "testando2", value: "teste2" } ] }**

**Se tiver alguma sugestão de melhoria ou perceber algo errado, me avise 😉. Obrigada!**
