### PR TITLE
Triagem formulario

### DIFF
--- a/components/Dropdown/Dropdown.tsx
+++ b/components/Dropdown/Dropdown.tsx
@@ -2,11 +2,11 @@
 import * as Select from '@/components/ui/select';
 import { DropdownProps } from './DropdownProps';
 
-export function Dropdown({ options, placeholder }: DropdownProps) {
+export function Dropdown({ options, placeholder, onChange }: DropdownProps) {
 
   return (
     <div className='w-full'>
-      <Select.Root>
+      <Select.Root onValueChange={onChange}>
         <Select.Trigger aria-label={placeholder}>
           <Select.Value placeholder={placeholder} />
         </Select.Trigger>

--- a/components/Dropdown/DropdownProps.ts
+++ b/components/Dropdown/DropdownProps.ts
@@ -1,4 +1,5 @@
 export interface DropdownProps {
   options: { label: string; value: string }[],
-  placeholder?: string
+  placeholder?: string,
+  onChange: (value: string) => void
 }

--- a/components/FormField/FormField.tsx
+++ b/components/FormField/FormField.tsx
@@ -1,28 +1,32 @@
+import { forwardRef, ForwardRefRenderFunction } from "react";
 import { Hint } from "../Hint/Hint";
 import { Input } from "../Input/Input";
 import { Label } from "../Label/Label";
 import { FormFieldProps } from "./FormFieldProps";
 
-export function FormField({ label, type, value, placeholder, onChange, icon, message, showError, ...rest }: FormFieldProps) {
+const Form: ForwardRefRenderFunction<HTMLInputElement, FormFieldProps> = ({ label, type, placeholder, icon, message, hasError, campoObrigatorio, ...rest }, ref) => {
   return (
-    <>
+    <div className="inline">
       <Label
         label={label}
+        campoObrigatorio
         {...rest} />
 
       <Input
         type={type}
-        value={value}
         placeholder={placeholder}
-        onChange={onChange}
+        ref={ref}
         {...rest} />
 
-      {showError && (
+      {hasError && (
         <Hint
           icon={icon}
           message={message}
+          hasError={hasError}
           {...rest} />
       )}
-    </>
+    </div>
   )
 }
+
+export const FormField = forwardRef(Form);

--- a/components/FormField/FormFieldProps.ts
+++ b/components/FormField/FormFieldProps.ts
@@ -1,12 +1,11 @@
-import { ChangeEvent, ElementType, InputHTMLAttributes } from "react";
+import { ElementType, InputHTMLAttributes } from "react";
 
 export interface FormFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string,
   type: 'text' | 'password' | 'email' | 'number' | 'date',
-  value: string,
   placeholder: string,
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void,
-  showError?: boolean,
+  hasError?: boolean,
   icon?: ElementType,
-  message?: string
+  message?: string,
+  campoObrigatorio?: boolean
 }

--- a/components/Input/Input.tsx
+++ b/components/Input/Input.tsx
@@ -4,10 +4,10 @@ import {
   RiEyeLine,
   RiEyeOffLine
 } from '@remixicon/react';
-import { useState } from 'react';
+import { forwardRef, ForwardRefRenderFunction, useState } from 'react';
 import { InputProps } from './InputProps';
 
-export function Input({ type, value, placeholder, iconStart, onChange, size, ...rest }: InputProps) {
+const InputBase: ForwardRefRenderFunction<HTMLInputElement, InputProps> = ({ type, placeholder, iconStart, ...rest }, ref) => {
   const [showPassword, setShowPassword] = useState(false);
 
   return (
@@ -17,8 +17,7 @@ export function Input({ type, value, placeholder, iconStart, onChange, size, ...
           {iconStart && <I.Icon as={iconStart} />}
           <I.Input
             {...rest}
-            onChange={onChange}
-            value={value}
+            ref={ref}
             type={type === "password" ? (showPassword ? "text" : "password") : type}
             placeholder={placeholder} />
 
@@ -36,3 +35,5 @@ export function Input({ type, value, placeholder, iconStart, onChange, size, ...
     </div>
   );
 }
+
+export const Input = forwardRef(InputBase);

--- a/components/Input/InputProps.ts
+++ b/components/Input/InputProps.ts
@@ -1,10 +1,8 @@
-import { ChangeEvent, ElementType, InputHTMLAttributes } from "react";
+import { ElementType } from "react";
 
-export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface InputProps {
   type: 'text' | 'password' | 'email' | 'number' | 'date';
-  value: string,
   placeholder: string,
   iconStart?: ElementType,
   hasError?: boolean,
-  onChange: (e: ChangeEvent<HTMLInputElement>) => void
 }

--- a/components/Textearea/Textearea.tsx
+++ b/components/Textearea/Textearea.tsx
@@ -1,20 +1,24 @@
 'use client';
 import * as T from '@/components/ui/textarea';
+import { forwardRef, ForwardRefRenderFunction } from 'react';
+import { Controller } from 'react-hook-form';
 import { TexteareaProps } from './TexteareaProps';
 
-export function Textarea({ placeholder, value, onChange, ...rest }: TexteareaProps) {
+const TextareaBase: ForwardRefRenderFunction<HTMLTextAreaElement, TexteareaProps> = ({ placeholder, name, rules, control, ...rest }) => {
   return (
-    <div className='w-full'>
-      <T.Root
-        {...rest}
-        placeholder={placeholder}
-        value={value}
-        onChange={onChange}>
-
-        <T.CharCounter
-          current={value.length}
-          max={500} />
-      </T.Root>
-    </div>
+    <Controller
+      name={name}
+      control={control}
+      rules={rules}
+      render={({ field }) => (
+        <div className="w-full">
+          <T.Root {...rest} placeholder={placeholder} {...field}>
+            <T.CharCounter current={field.value?.length || 0} max={500} />
+          </T.Root>
+        </div>
+      )}
+    />
   );
 }
+
+export const Textarea = forwardRef(TextareaBase);

--- a/components/Textearea/TexteareaProps.ts
+++ b/components/Textearea/TexteareaProps.ts
@@ -1,8 +1,10 @@
-import { ChangeEvent, TextareaHTMLAttributes } from "react";
+import { TextareaHTMLAttributes } from "react";
+import { Control, RegisterOptions } from "react-hook-form";
 
-export interface TexteareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement>  {
-  value: string,
+export interface TexteareaProps extends TextareaHTMLAttributes<HTMLTextAreaElement> {
+  name: string,
   placeholder: string,
+  rules?: RegisterOptions,
   hasError?: boolean,
-  onChange:  (e: ChangeEvent<HTMLTextAreaElement>) => void
+  control: Control<any>
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "react-aria-components": "^1.4.1",
         "react-day-picker": "8.10.1",
         "react-dom": "18.3.1",
+        "react-hook-form": "^7.54.2",
         "react-otp-input": "^3.1.1",
         "sonner": "^1.7.0",
         "tailwind-merge": "^2.5.4",
@@ -3733,6 +3734,10 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/alignui-nextjs-typescript-starter": {
+      "resolved": "",
+      "link": true
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -7334,6 +7339,22 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.54.2",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.54.2.tgz",
+      "integrity": "sha512-eHpAUgUjWbZocoQYUHposymRb4ZP6d0uwUnooL2uOybA9/3tPUvoAKqEWK1WaSiTxxOfTpffNZP7QwlnM3/gEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-aria-components": "^1.4.1",
     "react-day-picker": "8.10.1",
     "react-dom": "18.3.1",
+    "react-hook-form": "^7.54.2",
     "react-otp-input": "^3.1.1",
     "sonner": "^1.7.0",
     "tailwind-merge": "^2.5.4",


### PR DESCRIPTION
# Componentes Reutilizáveis - Modificações:
Realizado alterações para o funcionamento do React Hook Form e de estilo

## Descrição:

### O que foi adicionado?
- React Hook Form: foi adicionado para o gerenciamento do formulário 

### O que foi mudado?

**Componente Dropdown:** 
- Modificações -> acrescentado 'onValueChange' e props 'onChange'
- Motivo -> essas mudanças permitem que o valor selecionado seja reconhecido quando o componente for utilizado dentro de um **Controller** do React Hook Form

**Componentes FormField, Input e Textarea:** 
- Modificações -> algumas props foram removidas, como value e onChange. Além disso, foi alterado para usarem o tipo ForwardRefRenderFunction
- Motivo -> a mudança para usar o tipo, foi implementada para facilitar o uso do register do React Hook Form. As props removidas foram pelo motivo do React Hook Form já lidar com o gerenciamento delas